### PR TITLE
update zeit to version v0.0.6

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,18 +1,19 @@
 # Maintainer: Jonas Strassel <info@jonas-strassel.de>
 
 pkgname=zeit
-pkgver=0.0.4
+pkgver=v0.0.6
+pkgver_number=0.0.6
 pkgrel=3
 arch=('x86_64' 'aarch64')
 url="https://github.com/mrusme/$pkgname"
 license=('GPL')
 pkgdesc='Zeit, erfassen. A command line tool for tracking time spent on activities. '
 
-source_x86_64=(${pkgname}-${pkgver}.tar.gz::${url}/releases/download/${pkgver}/zeit_linux_amd64.tar.gz)
-md5sums_x86_64=('565d82b16bd01ff7d1df1da3a8088fcc')
+source_x86_64=(${pkgname}-${pkgver}.tar.gz::${url}/releases/download/${pkgver}/zeit_${pkgver_number}_linux_amd64.tar.gz)
+md5sums_x86_64=('12468fd10159f9e4c58ac81bda5f8607')
 
-source_aarch64=(${pkgname}-${pkgver}.tar.gz::${url}/releases/download/${pkgver}/zeit_linux_arm64.tar.gz)
-md5sums_aarch64=('145b35f73580a8a3abe887b4d9edbf97')
+source_aarch64=(${pkgname}-${pkgver}.tar.gz::${url}/releases/download/${pkgver}/zeit_${pkgver_number}_linux_arm64.tar.gz)
+md5sums_aarch64=('92289a319b4fa5483ddfadfa887930dd')
 
 package() {
   install -D ${pkgname} ${pkgdir}/usr/bin/${pkgname}


### PR DESCRIPTION
Hello @boredland,

zeit latest version is v0.0.6. The 0.0.4-3 has even some bugs in it, which have been fixed with the latest versions. 

Tested the PKGBUILD locally and works fine. I did not had time to check your .github file for potential changes. If further changes are needed post a comment and I will gladly take care of them.

Wish you the best and thanks for making manjaro-sway possible 👍🏿 